### PR TITLE
Adjust probing speeds and offsets

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -564,8 +564,8 @@
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
 #if defined(AON_DEBUG_MODE)
-    #define X_MAX_ACCELERATION_SCALAR 0.5
-    #define Y_MAX_ACCELERATION_SCALAR 0.5
+    #define X_MAX_ACCELERATION_SCALAR 3
+    #define Y_MAX_ACCELERATION_SCALAR 3
     #define Z_MAX_ACCELERATION_SCALAR 1.0
     #define E_MAX_ACCELERATION_SCALAR 1.0
     #define DEFAULT_MAX_ACCELERATION      { 3000*X_MAX_ACCELERATION_SCALAR, 3000*Y_MAX_ACCELERATION_SCALAR, 50*Z_MAX_ACCELERATION_SCALAR, 10000*E_MAX_ACCELERATION_SCALAR }
@@ -595,8 +595,8 @@
  */
 
 #if defined(AON_DEBUG_MODE)
-  #define DEFAULT_XJERK_SCALAR 1.5         
-  #define DEFAULT_YJERK_SCALAR 1.5                
+  #define DEFAULT_XJERK_SCALAR 2.5         
+  #define DEFAULT_YJERK_SCALAR 2.5                
   #define DEFAULT_ZJERK_SCALAR 1.0                 
   #define DEFAULT_EJERK_SCALAR 1.0              
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -564,8 +564,8 @@
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
 #if defined(AON_DEBUG_MODE)
-    #define X_MAX_ACCELERATION_SCALAR 3
-    #define Y_MAX_ACCELERATION_SCALAR 3
+    #define X_MAX_ACCELERATION_SCALAR 1.0
+    #define Y_MAX_ACCELERATION_SCALAR 1.0
     #define Z_MAX_ACCELERATION_SCALAR 1.0
     #define E_MAX_ACCELERATION_SCALAR 1.0
     #define DEFAULT_MAX_ACCELERATION      { 3000*X_MAX_ACCELERATION_SCALAR, 3000*Y_MAX_ACCELERATION_SCALAR, 50*Z_MAX_ACCELERATION_SCALAR, 10000*E_MAX_ACCELERATION_SCALAR }
@@ -595,8 +595,8 @@
  */
 
 #if defined(AON_DEBUG_MODE)
-  #define DEFAULT_XJERK_SCALAR 2.5         
-  #define DEFAULT_YJERK_SCALAR 2.5                
+  #define DEFAULT_XJERK_SCALAR 1.0         
+  #define DEFAULT_YJERK_SCALAR 1.0                
   #define DEFAULT_ZJERK_SCALAR 1.0                 
   #define DEFAULT_EJERK_SCALAR 1.0              
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -730,7 +730,7 @@
 #define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
 
 // X and Y axis travel speed (mm/m) between probes
-#define XY_PROBE_SPEED 18000
+#define XY_PROBE_SPEED 30000
 
 // Speed for the first approach when double-probing (MULTIPLE_PROBING == 2)
 #define Z_PROBE_SPEED_FAST HOMING_FEEDRATE_Z
@@ -757,7 +757,7 @@
  * Example: `M851 Z-5` with a CLEARANCE of 4  =>  9mm from bed to nozzle.
  *     But: `M851 Z+1` with a CLEARANCE of 2  =>  2mm from bed to nozzle.
  */
-#define Z_CLEARANCE_DEPLOY_PROBE   80 // Z Clearance for Deploy/Stow
+#define Z_CLEARANCE_DEPLOY_PROBE   20 // Z Clearance for Deploy/Stow
 #define Z_CLEARANCE_BETWEEN_PROBES  8 // Z Clearance between probe points
 
 // For M851 give a range for adjusting the Z probe offset

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -563,7 +563,15 @@
  * Override with M201
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 50, 10000 }
+#if defined(AON_DEBUG_MODE)
+    #define X_MAX_ACCELERATION_SCALAR 0.5
+    #define Y_MAX_ACCELERATION_SCALAR 0.5
+    #define Z_MAX_ACCELERATION_SCALAR 1.0
+    #define E_MAX_ACCELERATION_SCALAR 1.0
+    #define DEFAULT_MAX_ACCELERATION      { 3000*X_MAX_ACCELERATION_SCALAR, 3000*Y_MAX_ACCELERATION_SCALAR, 50*Z_MAX_ACCELERATION_SCALAR, 10000*E_MAX_ACCELERATION_SCALAR }
+#else
+  #define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 50, 10000 }
+#endif
 
 /**
  * Default Acceleration (change/s) change = mm/s
@@ -585,10 +593,25 @@
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
  */
-#define DEFAULT_XJERK                 15.0/2 //half jerks
-#define DEFAULT_YJERK                 15.0/2
-#define DEFAULT_ZJERK                  0.4/2
-#define DEFAULT_EJERK                  5.0
+
+#if defined(AON_DEBUG_MODE)
+  #define DEFAULT_XJERK_SCALAR 1.5         
+  #define DEFAULT_YJERK_SCALAR 1.5                
+  #define DEFAULT_ZJERK_SCALAR 1.0                 
+  #define DEFAULT_EJERK_SCALAR 1.0              
+
+  #define DEFAULT_XJERK                 15.0 * DEFAULT_XJERK_SCALAR
+  #define DEFAULT_YJERK                 15.0 * DEFAULT_YJERK_SCALAR
+  #define DEFAULT_ZJERK                  0.4 * DEFAULT_ZJERK_SCALAR
+  #define DEFAULT_EJERK                  5.0 * DEFAULT_EJERK_SCALAR
+
+#else
+  #define DEFAULT_XJERK                 15.0
+  #define DEFAULT_YJERK                 15.0
+  #define DEFAULT_ZJERK                  0.4
+  #define DEFAULT_EJERK                  5.0
+#endif
+
 
 //===========================================================================
 //============================= Z Probe Options =============================
@@ -942,7 +965,7 @@
   #define LEFT_PROBE_BED_POSITION 110
   #define RIGHT_PROBE_BED_POSITION (X_BED_SIZE - 50)
   #define FRONT_PROBE_BED_POSITION 60
-  #define BACK_PROBE_BED_POSITION (Y_BED_SIZE)
+  #define BACK_PROBE_BED_POSITION (Y_BED_SIZE - 20)
 
   // Probe along the Y axis, advancing X after each column
   //#define PROBE_Y_FIRST

--- a/Marlin/src/gcode/geometry/G92.cpp
+++ b/Marlin/src/gcode/geometry/G92.cpp
@@ -126,10 +126,11 @@ void GcodeSuite::G92() {
 
   bool didR = parser.seenval('R');
   if (didR){
-    primaryZTO = 0;
-    secondaryZTO = 0;
+    const float z_reset_value = parser.value_axis_units(Z_AXIS);
+    primaryZTO = z_reset_value;
+    secondaryZTO = z_reset_value;
     SERIAL_ECHO_START();
-    SERIAL_PROTOCOLLNPGM("Z toolhead offsets have been reset.");
+    SERIAL_ECHOLNPAIR("Z toolhead offset values reset to: ", z_reset_value);
   }
 
   if (didXYZ || didA)

--- a/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
@@ -78,7 +78,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN   12
+  #define Z_MIN_PROBE_PIN   22
 #endif
 
 //
@@ -154,7 +154,7 @@
 #define FAN2_PIN			5	//CHAMBER FAN
 
 //Filament runout - Dyze Sentinel
-#define FIL_RUNOUT_PIN      22
+#define FIL_RUNOUT_PIN      49
 
 //
 // LCD / Controller


### PR DESCRIPTION
This makes minor adjustments to probing speeds and offsets for the new and improved bed, and activates the `G92 R` custom gcode command.