### PR TITLE
Disable chamber temperature crash

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -453,6 +453,7 @@
  */
 
 #define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+#define THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS 1 // Ignore n hotends from end(eg. with extruders 0, 1, 2 & n=1; extruder 2 will not get thermal protection)
 //#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -96,8 +96,8 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 #endif
 
 #if WATCH_HOTENDS
-  uint16_t Temperature::watch_target_temp[HOTENDS] = { 0 };
-  millis_t Temperature::watch_heater_next_ms[HOTENDS] = { 0 };
+  uint16_t Temperature::watch_target_temp[HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS] = { 0 };
+  millis_t Temperature::watch_heater_next_ms[HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS] = { 0 };
 #endif
 
 #if WATCH_THE_BED

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -96,8 +96,8 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 #endif
 
 #if WATCH_HOTENDS
-  uint16_t Temperature::watch_target_temp[HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS] = { 0 };
-  millis_t Temperature::watch_heater_next_ms[HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS] = { 0 };
+  uint16_t Temperature::watch_target_temp[HOTENDS] = { 0 };
+  millis_t Temperature::watch_heater_next_ms[HOTENDS] = { 0 };
 #endif
 
 #if WATCH_THE_BED

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1394,6 +1394,19 @@ void Temperature::init() {
           break;
         }
         else if (PENDING(millis(), *timer)) break;
+
+        #if THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS
+          if(heater_index >= (HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS) ){
+            SERIAL_ECHO_START();
+            SERIAL_ECHOPGM("Ignoring bad temperature for this hotend: ");
+            SERIAL_ECHOPAIR(" ;  heater_id:", heater_id);
+            SERIAL_ECHOPAIR(" ;  Timer:", *timer);
+            SERIAL_ECHOPAIR(" ;  Temperature:", current);
+            SERIAL_ECHOPAIR(" ;  Target Temp:", target);
+            break;
+          }
+        #endif
+
         *state = TRRunaway;
       case TRRunaway:
         _temp_error(heater_id, PSTR(MSG_T_THERMAL_RUNAWAY), PSTR(MSG_THERMAL_RUNAWAY));

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1397,12 +1397,6 @@ void Temperature::init() {
 
         #if THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS
           if(heater_index >= (HOTENDS - THERMAL_PROTECTION_IGNORE_TRAILING_HOTENDS) ){
-            SERIAL_ECHO_START();
-            SERIAL_ECHOPGM("Ignoring bad temperature for this hotend: ");
-            SERIAL_ECHOPAIR(" ;  heater_id:", heater_id);
-            SERIAL_ECHOPAIR(" ;  Timer:", *timer);
-            SERIAL_ECHOPAIR(" ;  Temperature:", current);
-            SERIAL_ECHOPAIR(" ;  Target Temp:", target);
             break;
           }
         #endif


### PR DESCRIPTION
Description:
-Chamber is extruder 2 in terms of firmware
-however, unlike an extruder, chamber will not overheat if left on indefinately
-also, sometimes door is opened while chamber is hot, causes a firmware induced crash
-this patch disables chamber crashing when door is opened 
