### PR TITLE
Adjust safe homing points

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1001,8 +1001,8 @@
 #define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #define Z_SAFE_HOMING_X_POINT (-20)    // X point for Z homing when homing all axis (G28).
-  #define Z_SAFE_HOMING_Y_POINT (-20)    // Y point for Z homing when homing all axis (G28).
+  #define Z_SAFE_HOMING_X_POINT (0)    // X point for Z homing when homing all axis (G28).
+  #define Z_SAFE_HOMING_Y_POINT (0)    // Y point for Z homing when homing all axis (G28).
 #endif
 
 // Homing speeds (mm/m)


### PR DESCRIPTION
Homing Z was not working because the Y min position at the endstops was [changed to be 0](https://github.com/aon3d/Marlin/commit/eccce9a4925bd8cedc188b5ceb0c39f2ecde31bf#diff-8270513bcf2a548cd418cdfe123f27d3R773), the result of which makes it impossible for the toolhead(s) to ever be in a "safe" position for homing Z (i.e. `(-20, -20)`).

I've set both safe home points to 0, although we should discuss the desired coordinate system offset for the machines. There are two options (considering `T0`, but `T1` will  be the same, just mirrored across the bed centerline).

@caenan0