### PR TITLE
Increase residency time for bed hysteresis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -305,8 +305,8 @@
 #define TEMP_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
 // Bed temperature must be close to target for this long before M190 returns success
-#define TEMP_BED_RESIDENCY_TIME 5  // (seconds)
-#define TEMP_BED_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
+#define TEMP_BED_RESIDENCY_TIME 120 // (seconds)
+#define TEMP_BED_HYSTERESIS 5       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -305,7 +305,7 @@
 #define TEMP_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 
 // Bed temperature must be close to target for this long before M190 returns success
-#define TEMP_BED_RESIDENCY_TIME 120 // (seconds)
+#define TEMP_BED_RESIDENCY_TIME 180 // (seconds)
 #define TEMP_BED_HYSTERESIS 5       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_BED_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 


### PR DESCRIPTION
Increases the residency time value to match what is set on the RnD printers (apparently).

@aon3d/firmware 