### PR TITLE
Enable case fan for electronics

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -181,9 +181,9 @@
  * The fan will turn on automatically whenever any stepper is enabled
  * and turn off after a set period after all steppers are turned off.
  */
-//#define USE_CONTROLLER_FAN
+#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN FAN1_PIN  // Set a custom pin for the controller fan
+  #define CONTROLLER_FAN_PIN FAN3_PIN  // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
 #endif
@@ -191,7 +191,7 @@
 // When first starting the main fan, run it at full speed for the
 // given number of milliseconds.  This gets the fan spinning reliably
 // before setting a PWM value. (Does not work with software PWM for fan on Sanguinololu)
-//#define FAN_KICKSTART_TIME 100
+#define FAN_KICKSTART_TIME 100
 
 // This defines the minimal speed for the main fan, run in PWM mode
 // to enable uncomment and set minimal PWM speed for reliable running (1-255)

--- a/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
@@ -152,6 +152,7 @@
 #define FAN_PIN             4	//T0 PART COOLING
 #define FAN1_PIN			5	//T1 PART COOLING
 #define FAN2_PIN			16	//CHAMBER FAN
+#define FAN3_PIN            11  //ELECTRONICS ENCLOSURE FAN
 
 //Filament runout - Dyze Sentinel
 #define FIL_RUNOUT_PIN      22


### PR DESCRIPTION
An issue has apparently arisen where the electronics enclosure fan does not run while the printer is active - this seems to resolve it on one machine I tested with, however it still does not work fully on M1-4 (likely due to the casefan itself being faulty). 

I'm unsure if this config setting was lost when we began using VC, or if something else has changed, so please take a look @caenan0 and @walkmantasaurusrex to see if it jogs your memory.